### PR TITLE
Fix trailing period handling in clean_ref

### DIFF
--- a/afecd_csv_embedding.py
+++ b/afecd_csv_embedding.py
@@ -98,11 +98,25 @@ def as_str(x) -> str:
     return s
 
 def clean_ref(raw: str) -> str:
-    """Normalize a ref like 2.1, 2.1., '2.1 '."""
+    """Normalize a section reference.
+
+    The original implementation attempted to strip a trailing period only when
+    the reference contained a single dot (e.g. ``"2."``).  Multi-part
+    references such as ``"2.1."`` therefore kept their trailing period, which
+    later caused lookups to fail because the keys no longer matched.  We simply
+    need to drop any trailing ``.`` regardless of how many segments are in the
+    reference.
+
+    Examples::
+
+        clean_ref("2.1.") -> "2.1"
+        clean_ref("2.")   -> "2"
+
+    """
     s = as_str(raw)
     s = s.replace("..", ".").strip()
-    if s.endswith(".") and s.count(".") == 1:
-        s = s[:-1]
+    # remove any trailing periods (e.g. "2.1." -> "2.1")
+    s = s.rstrip(".")
     return s
 
 def get_col(df: pd.DataFrame, candidates: List[str]) -> Optional[str]:

--- a/tests/test_clean_ref.py
+++ b/tests/test_clean_ref.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+# Ensure the project root is on sys.path for direct module imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import afecd_csv_embedding as m
+
+def test_clean_ref_trims_trailing_periods():
+    assert m.clean_ref('2.1.') == '2.1'
+    assert m.clean_ref('2.') == '2'
+    assert m.clean_ref('2.1') == '2.1'
+    assert m.clean_ref('2..1.') == '2.1'


### PR DESCRIPTION
## Summary
- normalize section references by stripping trailing periods
- add tests for clean_ref edge cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68994f5be4d8832da6ee5a3b3f16abfd